### PR TITLE
update@fork: kubejs@startup_scripts: easier functions

### DIFF
--- a/kubejs/startup_scripts/Block.js
+++ b/kubejs/startup_scripts/Block.js
@@ -21,7 +21,7 @@ StartupEvents.registry("block", (event) => {
    * @param {string} SoundType -方块破坏&放置声音
    * @param {number} Hardness -方块硬度
    * @param {number} ResisTance -方块爆炸抗性
-   * @param {string} Tool -方块破坏需要的工具类型
+   * @param {string|string[]} Tool -方块破坏需要的工具类型
    * @param {string} Grade -方块需要的工具材质
    */
   function customBlockBuilder(
@@ -30,14 +30,21 @@ StartupEvents.registry("block", (event) => {
     Hardness,
     ResisTance,
     Tool,
-    Grade
+    Grade = ''
   ) {
-    event.create(ID)
+    const block = event.create(ID)
       .soundType(SoundType)
       .hardness(Hardness)
-      .resistance(ResisTance)
-      .tagBlock(toolType[Tool])
-      .tagBlock(miningLevel[Grade])
-      .requiresTool(true);
+      .resistance(ResisTance);
+    if (Array.isArray(Tool)) {
+      Tool.forEach(v => block.tagBlock(toolType[v]));
+    } else {
+      block.tagBlock(toolType[Tool]);
+    }
+
+    if (!!Grade) {
+      block.tagBlock(miningLevel[Grade])
+        .requiresTool(true);
+    }
   }
 });

--- a/kubejs/startup_scripts/Item.js
+++ b/kubejs/startup_scripts/Item.js
@@ -2,20 +2,29 @@ StartupEvents.registry("item", (event) => {
   /**
    *
    * @param {string} id -注册方块ID
-   * @param {string} rarity -注册方块稀有度
-   * @param {boolean} glow -注册方块是否发光
+   * @param {string} rarity -注册方块稀有度 默认`common`
+   * @param {boolean} glow -注册方块是否发光 默认`false`
    *
    */
-  function customItemBuilder(id, rarity, glow) {
+  function customItemBuilder(id, rarity = 'common', glow = false) {
     event.create(id).rarity(rarity).glow(glow);
   }
 
+  /**
+   * @type {string|[string,string?,boolean?]}
+   */
   let itemData = [
     ["stone_grain", "common", false], //石子
-    ["stone_rod", "common", false], //石棍
+    // ["stone_rod", "common", false], //石棍
+    "stone_rod" // 简化
   ];
 
-  itemData.forEach(([ids, rarity, glow]) => {
-    customItemBuilder(ids, rarity, glow);
+  itemData.forEach((data) => {
+    if(Array.isArray(data)){
+      let [ids, rarity, glow] = data;
+      customItemBuilder(ids, rarity, glow);
+    }else {
+      customItemBuilder(data);
+    }
   });
 });


### PR DESCRIPTION
允许通过简写声明物品和方块

物品：`[id:string,rarity:string,glow:boolean]` -> `id:string`|`[id:string,rarity?:string='common',glow?:boolean=false]`

方块：材质等级默认无 工具类型可传入`string[]`